### PR TITLE
fix: add the attrs package as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,15 @@ setup(
     name='unified_range',
     description="Convert between semver range and maven version range",
     url="https://github.com/snyk/unified-range",
-    version='0.0.5',
+    version='0.0.6',
     # packages=['unified_range', ],
     packages=find_packages(),
     license='MIT License',
     long_description=long_description,
     long_description_content_type='text/markdown',
+    install_requires=[
+        'attrs',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_filter_versions.py
+++ b/tests/test_filter_versions.py
@@ -126,6 +126,7 @@ def test_2_param_range(left, v1, v2, right):
        v21=versions(),
        v22=versions(),
        right2=rights())
+@settings(suppress_health_check=(HealthCheck.filter_too_much,))
 def test_two_2_param_ranges(left1, v11, v12, right1,
                             left2, v21, v22, right2):
     assume(v11 < v12)


### PR DESCRIPTION
The last addition of the `attrs` package was not included in the `setup.py` file, causing an error when the this library is used. This PR fixes that.