### PR TITLE
docs: filter_versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # unified-range
 
-Based on the VersionRange [model](https://github.com/apache/maven/tree/master/maven-artifact/src/main/java/org/apache/maven/artifact/versioning) and [spec](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html) of maven. 
+Based on the VersionRange [model](https://github.com/apache/maven/tree/master/maven-artifact/src/main/java/org/apache/maven/artifact/versioning)
+and [spec](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html) of maven.
 
 Library to convert semver ranges to unified-range and the over way around.
 Currently only supported for comparator semver ranges.
 
 ## Install
-1. Use pipenv 
+1. Use pipenv
 
 `pipenv install unified-range`
 
 or
- 
+
 2. Use pip directly
 
 `pip install unified-range`
@@ -39,4 +40,6 @@ or
 
 5. Filter versions list by list of ranges:
 
-`filtered_lst = api.filter_versions(ordered_version_list, ranges)`
+`filtered_lst = api.filter_versions(ascending_version_list, ranges)`
+The versions in `ascending_version_list` should be sorted in ascending order,
+from oldest to newest, and contain all the versions for the package.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='unified_range',
     description="Convert between semver range and maven version range",
     url="https://github.com/snyk/unified-range",
-    version='0.0.6',
+    version='0.0.7',
     # packages=['unified_range', ],
     packages=find_packages(),
     license='MIT License',

--- a/unified_range/api.py
+++ b/unified_range/api.py
@@ -36,10 +36,11 @@ def unified_range(spec: str) -> UnifiedVersionRange:
     return UnifiedVersionRange.create_from_spec(spec)
 
 
-def filter_versions(ord_versions: List[str], ranges: List[str]) -> List[str]:
+def filter_versions(asc_versions: List[str], ranges: List[str]) -> List[str]:
     """
-    Return list of versions (ordered the same way) that not satisfies any range.
-    Versions must be ordered and include all the versions that are specified in the ranges.
+    Return an ordered list of versions that not satisfies any range.
+    Input versions must be ordered in ascending order and include all
+    the versions that are specified in the ranges.
     :param ord_versions:
     :param ranges:
     :return:
@@ -54,4 +55,4 @@ def filter_versions(ord_versions: List[str], ranges: List[str]) -> List[str]:
             raise ValueError(
                 f'Not a valid semver or unified/maven range - ({rng})')
 
-    return utils.not_included_versions(ord_versions, rngs_unified)
+    return utils.not_included_versions(asc_versions, rngs_unified)

--- a/unified_range/utils.py
+++ b/unified_range/utils.py
@@ -226,7 +226,6 @@ def not_included_versions(ordered_version_list: List[str],
             upper_index = _get_index(ordered_version_list, upper.version,
                                      upper.inclusive)
             # use of on the list and intersection .. [:]
-            print({upper.version: upper_index, lower.version: lower_index})
             # [X,Y]
             if lower_index is not None and upper_index is not None:
                 rst_indices.append(set(range(lower_index, upper_index)))


### PR DESCRIPTION
Explicitly state that version given to filter_versions should be sorted in ascending order.