### PR TITLE
chore: codeowners -> sec-eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/sec-eng


### PR DESCRIPTION
Mark that code in this repository must be reviewed by sec-eng.