### PR TITLE
chore: different name for job and workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_release:
+  test_and_release:
     jobs:
       - test:
           name: Run Tests - python 3.9


### PR DESCRIPTION
Default branch name needed to be changed to main to apply the release step.

Merge to main workflow build - https://app.circleci.com/pipelines/github/snyk/unified-range/28/workflows/9e28d691-0aeb-4b6a-ba63-e0adc25e8434