### PR TITLE
chore: remove ci context snyk-security-rnd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,28 +117,24 @@ workflows:
       - test:
           name: Run Tests - python 3.10
           executor_name: python310
-          context: snyk-security-rnd
           filters:
             branches:
               ignore: main
       - test:
           name: Run Tests - python 3.9
           executor_name: python39
-          context: snyk-security-rnd
           filters:
             branches:
               ignore: main
       - test:
           name: Run Tests - python 3.8
           executor_name: python38
-          context: snyk-security-rnd
           filters:
             branches:
               ignore: main
       - test:
           name: Run Tests - python 3.7
           executor_name: python37
-          context: snyk-security-rnd
           filters:
             branches:
               ignore: main


### PR DESCRIPTION
CircleCI context snyk-security-rnd is now deleted. 
This pr removes the context from unified-range

https://snyksec.atlassian.net/browse/RKT-3400